### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "CLI tool to alter words seamlessly while preserving casing"
 tags = ["cli", "refactor", "alter", "rename"]
+repository = "https://github.com/jnsahaj/altr"
 
 [dependencies]
 clap = { version = "4.4.18", features = ["derive"] }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.